### PR TITLE
Prevent the value of the ‘extremes’ setting from being overwritten

### DIFF
--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -301,7 +301,7 @@ class Http
      */
     public function getRequestRead(Query $query, $whereInFile = null)
     {
-        $urlParams = ['readonly' => 1, 'extremes' => 1];
+        $urlParams = ['readonly' => 1];
         $query_as_string = false;
 
         if ($whereInFile instanceof WhereInFile && $whereInFile->size()) {


### PR DESCRIPTION
Свойство уже задаётся в конструкторе ClickHouseDB\Client, а указание его здесь делает настройку бесполезной, т.к. значение всегда перезаписывается на 1.