### PR TITLE
Insert with associative array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
   },
   "require-dev": {
     "ext-curl": "*",
-    "phpunit/phpunit": ">=5.5.0"
+    "phpunit/phpunit": "5.5.*"
   },
   "autoload": {
     "files": ["include.php"]
   },
   "autoload-dev": {
-    "files": ["include.php","tests/test_functions.php"]
+    "files": ["include.php"]
   }
 }

--- a/include.php
+++ b/include.php
@@ -26,4 +26,6 @@ include_once __DIR__ . '/src/Transport/CurlerRolling.php';
 include_once __DIR__ . '/src/Transport/CurlerRequest.php';
 include_once __DIR__ . '/src/Transport/CurlerResponse.php';
 include_once __DIR__ . '/src/Transport/StreamInsert.php';
+//Composer
+include_once __DIR__ . '/vendor/autoload.php';
 

--- a/tests/InsertAssocTest.php
+++ b/tests/InsertAssocTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: maelstorm
+ * Date: 21.11.17
+ * Time: 15:29
+ */
+
+use PHPUnit\Framework\TestCase;
+
+class InsertAssocTest extends TestCase
+{
+    /**
+     * @var \ClickHouseDB\Client
+     */
+    private $db;
+
+    /**
+     * @throws Exception
+     */
+    public function setUp()
+    {
+        //на самом деле настоящие запросы мы проводить не будем
+        //тестируем не клиент (у него есть свои тесты), а подготовку данных
+        $config = [
+            'host'     => 'localhost',
+            'port'     => 9000,
+            'username' => 'default',
+            'password' => ''
+        ];
+
+        $this->db = new ClickHouseDB\Client($config);
+    }
+
+    /**
+     *
+     */
+    public function tearDown()
+    {
+        //
+    }
+
+    public function testPrepareOneRow()
+    {
+        $toInsert = [
+            'one' => 1,
+            'two' => 2,
+            'thr' => 3,
+        ];
+        $exceptColumns = ['one','two','thr'];
+        $exceptValues = [[1,2,3]];
+        list($actualColumns, $actualValues) = $this->db->prepareInsertAssocBulk($toInsert);
+        $this->assertEquals($exceptValues, $actualValues);
+        $this->assertEquals($exceptColumns, $actualColumns);
+    }
+
+    public function testPrepareManyRowSuccess()
+    {
+        $oneRow = [
+            'one' => 1,
+            'two' => 2,
+            'thr' => 3,
+        ];
+        $toInsert = [$oneRow, $oneRow, $oneRow];
+        $exceptColumns = ['one','two','thr'];
+        $exceptValues = [[1,2,3],[1,2,3],[1,2,3]];
+        list($actualColumns, $actualValues) = $this->db->prepareInsertAssocBulk($toInsert);
+        $this->assertEquals($exceptValues, $actualValues);
+        $this->assertEquals($exceptColumns, $actualColumns);
+    }
+
+    public function testPrepareManyRowFail()
+    {
+        $oneRow = [
+            'one' => 1,
+            'two' => 2,
+            'thr' => 3,
+        ];
+        $failRow = [
+            'two' => 2,
+            'one' => 1,
+            'thr' => 3,
+        ];
+        $toInsert = [$oneRow, $oneRow, $failRow];
+        $this->expectException(\ClickHouseDB\QueryException::class);
+        $this->expectExceptionMessage("Fields not match: two,one,thr and one,two,thr on element 2");
+        list($_, $__) = $this->db->prepareInsertAssocBulk($toInsert);
+    }
+}


### PR DESCRIPTION
Добавил возможность вставлять с помощью ассоциативного массива. Иногда это сильно удобнее.
Добавил немного тестов для этого, плюс пришлось пошаманить с настройками в composer.json - иначе phpUnit не запускался.
Во-первых, проблема с версией (6.x уже по другому несколько работает), во-вторых у вас под гитом нет tests/test_functions.php - все это пришлось выплить.