### PR TITLE
refs #29508. [Bug] Escape values

### DIFF
--- a/src/Query/Degenerations/Bindings.php
+++ b/src/Query/Degenerations/Bindings.php
@@ -61,7 +61,7 @@ class Bindings implements \ClickHouseDB\Query\Degeneration
 
             if (is_string($value)) {
                 $valueSet = $value;
-                $valueSetText = "'" . $value . "'";
+                $valueSetText = "'" . addslashes($value) . "'";
             }
 
             if ($valueSetText !== null) {


### PR DESCRIPTION
Fixes #34 

## Proposed Changes

```
"before" => "'Escape ' when using words like it's'"
"after"  => "'Escape \' when using words like it\'s'"
```