### PR TITLE
Add Coding Standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.phpcs-cache
+phpcs.xml
 phpunit.xml
 composer.lock
 vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,27 @@ jobs:
         - composer config minimum-stability dev
         - travis_retry composer update -n --prefer-dist
 
+    - stage: Pull request coding standard
+      if: type = pull_request
+      php: 7.1
+      install: travis_retry composer install --prefer-dist
+      script:
+        - |
+          if [ $TRAVIS_BRANCH != "master" ]; then
+            git remote set-branches --add origin $TRAVIS_BRANCH;
+            git fetch origin $TRAVIS_BRANCH;
+          fi
+        - git merge-base origin/$TRAVIS_BRANCH $TRAVIS_PULL_REQUEST_SHA || git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge --unshallow
+        - wget https://github.com/diff-sniffer/git/releases/download/0.1.0/git-phpcs.phar
+        - php git-phpcs.phar origin/$TRAVIS_BRANCH...$TRAVIS_PULL_REQUEST_SHA
+
+#    - stage: Coding standard
+#      if: NOT type = pull_request
+#      php: 7.1
+#      install: travis_retry composer install --prefer-dist
+#      script:
+#        - ./vendor/bin/phpcs
+
     - stage: Code Quality
       install: travis_retry composer install --prefer-dist
       script: vendor/bin/phpstan analyse -c phpstan.neon src

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,9 @@
     "ext-curl": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0",
-    "phpstan/phpstan": "^0.9.2"
+    "doctrine/coding-standard": "^4.0",
+    "phpstan/phpstan": "^0.9.2",
+    "phpunit/phpunit": "^7.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ruleset>
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="colors"/>
+    <arg name="parallel" value="80"/>
+    <arg name="cache" value=".phpcs-cache"/>
+
+    <!-- Ignore warnings, show progress of the run and show sniff names -->
+    <arg value="nps"/>
+
+    <file>src</file>
+
+    <rule ref="Doctrine"/>
+
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
+        <properties>
+            <property name="psr12Compatible" type="bool" value="true"/>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -3,6 +3,7 @@
 namespace ClickHouseDB\Query;
 
 use ClickHouseDB\Exception\QueryException;
+use function sizeof;
 
 class Query
 {
@@ -79,12 +80,9 @@ class Query
         return $this->format;
     }
 
-    /**
-     * @return string
-     */
-    public function toSql()
+    public function toSql() : string
     {
-        if (null !== $this->format) {
+        if ($this->format !== null) {
             $this->applyFormatQuery();
         }
 
@@ -92,8 +90,9 @@ class Query
         {
             foreach ($this->degenerations as $degeneration)
             {
-                if ($degeneration instanceof \ClickHouseDB\Query\Degeneration)
-                $this->sql=$degeneration->process($this->sql);
+                if ($degeneration instanceof Degeneration) {
+                    $this->sql=$degeneration->process($this->sql);
+                }
             }
         }
 


### PR DESCRIPTION
I have added a CI check for coding standard https://github.com/doctrine/coding-standard

It is set in a way that CI only checks the changed lines in pull requests and validates them against coding standard so there's no need to change to whole codebase for now.

I recommend to check into the branch, run `composer install` and then eg. `vendor/bin/phpcs src/Query/Degeneration/Bindings.php` so you can see what it does.

Also I have made changes to `toSql()` function in Query.php so it is in compliance with CS as a preview. Added a typehint so it is a BC break.

When changed lines are not compliant with CS, it reports it in Travis

![image](https://user-images.githubusercontent.com/327717/40014476-fb79230c-57b0-11e8-92e9-7cd0d1df5583.png)

Let me know what you think and whether we will merge this or not.
