### PR TITLE
Convert DateTimeInterface param to Clickhouse's datetime format

### DIFF
--- a/src/Query/Degeneration/Bindings.php
+++ b/src/Query/Degeneration/Bindings.php
@@ -2,6 +2,8 @@
 
 namespace ClickHouseDB\Query\Degeneration;
 
+use DateTimeInterface;
+
 class Bindings implements \ClickHouseDB\Query\Degeneration
 {
     /**
@@ -25,6 +27,10 @@ class Bindings implements \ClickHouseDB\Query\Degeneration
      */
     public function bindParam($column, $value)
     {
+        if ($value instanceof DateTimeInterface) {
+            $value = $value->format('Y-m-d H:i:s');
+        }
+
         $this->bindings[$column] = $value;
     }
 


### PR DESCRIPTION
I'm kind of used to this behavior from eg. [DBAL](https://github.com/doctrine/dbal/blob/87251a14b20107cf3015bd790e1f1f6c380bda42/lib/Doctrine/DBAL/Types/DateImmutableType.php#L50). I don't want to format datetime in every place I pass it to the query as this client can safely convert it for me.