### PR TITLE
Do not convert int parameters in array to string

### DIFF
--- a/tests/BindingsTest.php
+++ b/tests/BindingsTest.php
@@ -32,8 +32,8 @@ final class BindingsTest extends TestCase
             ],
             [
                 'select * from test. WHERE id IN (:id)',
-                ['id' => ['1', 2]],
-                "select * from test. WHERE id IN ('1','2')",
+                ['id' => [1, 2]],
+                'select * from test. WHERE id IN (1,2)',
             ],
             [
                 'select * from test. WHERE id IN (:id)',


### PR DESCRIPTION
I passed some integers as parameters but they were converted to string and therefore type mismatch occured in ClickHouse.