### PR TITLE
fix RegExp for testing new version of CH 18.1.0

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -995,7 +995,7 @@ class ClientTest extends TestCase
     public function testVersion() : void
     {
         $version = $this->client->getServerVersion();
-        $this->assertRegExp('/(^[0-9]+.[0-9]+.[0-9]+.*$)/mi', $version);
+        $this->assertRegExp('/(^[0-9]+.[0-9]+.[0-9]+(.[0-9]$|$))/mi', $version);
     }
 
     public function testServerSystemSettings()


### PR DESCRIPTION
A new version of the clickhouse server has a new version number format. PR fix it.