### PR TITLE
Cleanup transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ Last stable version for:
 Connect and select database:
 ```php
 $config = [
-    'host' => '192.168.1.1',
+    'host' => '127.0.0.1',
     'port' => '8123',
     'username' => 'default',
     'password' => ''
+    'database' => 'default',
 ];
 $db = new ClickHouseDB\Client($config);
-$db->database('default');
 $db->setTimeout(1.5);      // 1500 ms
 $db->setTimeout(10);       // 10 seconds
 $db->setConnectTimeOut(5); // 5 seconds
@@ -249,7 +249,7 @@ see example/exam5_error_async.php
 On fly read CSV file and compress zlib.deflate.
 
 ```php
-$db->settings()->max_execution_time(200);
+$db->setTimeout(200);
 $db->enableHttpCompression(true);
 
 $result_insert = $db->insertBatchFiles('summing_url_views', $file_data_names, [...]);
@@ -262,37 +262,11 @@ foreach ($result_insert as $fileName => $state) {
 
 see speed test `example/exam08_http_gzip_batch_insert.php`
 
-### Max execution time
+### Timeout
 
 ```php
-$db->settings()->max_execution_time(200); // second
+$db->setTimeout200); // second
 ```
-
-
-
-
-### Connection without port 
-
-```php 
-$config['host']='blabla.com';
-$config['port']=0;
-// getUri() === 'http://blabla.com'
-
-
-$config['host']='blabla.com/urls';
-$config['port']=8765;
-// getUri() === 'http://blabla.com/urls'
-
-$config['host']='blabla.com:2224';
-$config['port']=1234;
-// getUri() === 'http://blabla.com:2224'
-
-
-
-
-
-``` 
-
 
 ### tablesSize & databaseSize
 
@@ -432,28 +406,23 @@ SELECT {ifint VAR} result_if_intval_NON_ZERO {else} BLA BLA{/if}
 
 ### Settings
 
-3 way set any settings
+Settings documentation can be found at https://clickhouse.yandex/docs/en/operations/settings/.
+Default values can be found in ClickHouse [source code](https://github.com/yandex/ClickHouse/blob/master/dbms/src/Interpreters/Settings.h)
+
+Initial settings can be passed as a second argument to Client:
 ```php
-// in array config
-$config = [
-    'host' => 'x',
-    'port' => '8123',
-    'username' => 'x',
-    'password' => 'x',
-    'settings' => ['max_execution_time' => 100]
-];
-$db = new ClickHouseDB\Client($config);
-
-// settings via constructor
 $config = [
     'host' => 'x',
     'port' => '8123',
     'username' => 'x',
     'password' => 'x'
+    'database' => 'db_name',
 ];
-$db = new ClickHouseDB\Client($config, ['max_execution_time' => 100]);
+$db = new ClickHouseDB\Client($config, ['readonly' => 2]);
+```
 
-// set method
+Single settings can be set via set method:
+```
 $config = [
     'host' => 'x',
     'port' => '8123',
@@ -461,21 +430,25 @@ $config = [
     'password' => 'x'
 ];
 $db = new ClickHouseDB\Client($config);
-$db->settings()->set('max_execution_time', 100);
+$db->settings()->set('readonly', 2);
+```
 
-// apply array method
+Or apply multiple settings at once:
+```
 $db->settings()->apply([
-    'max_execution_time' => 100,
     'max_block_size' => 12345
 ]);
+```
 
-// check
-if ($db->settings()->getSetting('max_execution_time') !== 100) {
+To get value if set:
+```
+if ($db->settings()->get('readonly') !== 2) {
     throw new Exception('Bad work settings');
 }
-
-// see example/exam10_settings.php
 ```
+
+See example/exam10_settings.php
+
 ### Use session_id with ClickHouse
 
 
@@ -603,7 +576,7 @@ class my
 
 ```php
 $db = new ClickHouseDB\Client($config);
-$db->settings()->https();
+$db->setHttps(true);
 ```
 
 
@@ -618,19 +591,6 @@ print_r($db->getServerSystemSettings());
 print_r($db->getServerSystemSettings('merge_tree_min_rows_for_concurrent_read'));
 
 ```
-
-### ReadOnly ClickHouse user
-
-```php
-$config = [
-    'host' => '192.168.1.20',
-    'port' => '8123',
-    'username' => 'ro',
-    'password' => 'ro',
-    'readonly' => true
-];
-```
-
 
 ### Direct write to file
 

--- a/example/cluster/cluster_08_drop_partitions.php
+++ b/example/cluster/cluster_08_drop_partitions.php
@@ -9,8 +9,8 @@ $config = include_once __DIR__ . '/00_config_connect.php';
 
 
 $db = new ClickHouseDB\Client($config);
-$db->settings()->set('replication_alter_partitions_sync',2);
-$db->settings()->set('experimental_allow_extended_storage_definition_syntax',1);
+$db->getSettings()->set('replication_alter_partitions_sync', 2);
+$db->getSettings()->set('experimental_allow_extended_storage_definition_syntax', 1);
 
 
 for ( $looop=1;$looop<100;$looop++)

--- a/example/exam01_select.php
+++ b/example/exam01_select.php
@@ -7,7 +7,7 @@ $config = include_once __DIR__ . '/00_config_connect.php';
 
 $db = new ClickHouseDB\Client($config);
 //$db->verbose();
-$db->settings()->readonly(false);
+$db->getSettings()->readonly(false);
 
 
 $result = $db->select(

--- a/example/exam02_createtable.php
+++ b/example/exam02_createtable.php
@@ -10,7 +10,7 @@ $db = new ClickHouseDB\Client($config);
 
 // ---------------------------- Write ----------------------------
 echo "\n-----\ntry write:create_table\n";
-$db->database('default');
+$db->setDatabase('default');
 //------------------------------------------------------------------------------
 
 echo 'Tables EXISTS: ' . json_encode($db->showTables()) . PHP_EOL;

--- a/example/exam03_batch_insert.php
+++ b/example/exam03_batch_insert.php
@@ -10,7 +10,7 @@ include_once __DIR__ . '/Helper.php';
 $config = include_once __DIR__ . '/00_config_connect.php';
 
 $db = new ClickHouseDB\Client($config);
-$db->enableHttpCompression(true);
+$db->setHttpCompression(true);
 
 $db->write("DROP TABLE IF EXISTS summing_url_views");
 $db->write('

--- a/example/exam08_http_gzip_batch_insert.php
+++ b/example/exam08_http_gzip_batch_insert.php
@@ -48,7 +48,7 @@ echo "--------------------------------------------------------------------------
 echo "insert ALL file async NO gzip:\n";
 
 
-$db->settings()->max_execution_time(200);
+$db->setTimeout(200);
 $time_start = microtime(true);
 
 $result_insert = $db->insertBatchFiles('summing_url_views', $file_data_names, [
@@ -67,7 +67,7 @@ print_r($db->select('select sum(views) from summing_url_views')->rows());
 echo "--------------------------------------- enableHttpCompression -------------------------------------------------------------\n";
 echo "insert ALL file async + GZIP:\n";
 
-$db->enableHttpCompression(true);
+$db->setHttpCompression(true);
 $time_start = microtime(true);
 
 $result_insert = $db->insertBatchFiles('summing_url_views', $file_data_names, [

--- a/example/exam09_drop_partitions.php
+++ b/example/exam09_drop_partitions.php
@@ -43,7 +43,7 @@ if ($create) {
     echo "--------------------------------------- insert -------------------------------------------------------------\n";
     echo "insert ALL file async + GZIP:\n";
 
-    $db->enableHttpCompression(true);
+    $db->setHttpCompression(true);
     $time_start = microtime(true);
 
     $result_insert = $db->insertBatchFiles('summing_partions_views', $file_data_names, [

--- a/example/exam10_settings.php
+++ b/example/exam10_settings.php
@@ -7,9 +7,9 @@ $config = include_once __DIR__ . '/00_config_connect.php';
 
 
 
-$db = new ClickHouseDB\Client($config, ['max_execution_time' => 100]);
+$db = new ClickHouseDB\Client($config, ['readonly' => 100]);
 
-if ($db->settings()->getSetting('max_execution_time') !== 100) {
+if ($db->getSettings()->getSetting('readonly') !== 2) {
     throw new Exception("Bad work settings");
 }
 
@@ -23,9 +23,9 @@ $config = [
 ];
 
 $db = new ClickHouseDB\Client($config);
-$db->settings()->set('max_execution_time', 100);
+$db->getSettings()->set('readonly', 2);
 
-if ($db->settings()->getSetting('max_execution_time') !== 100) {
+if ($db->getSettings()->getSetting('readonly') !== 2) {
     throw new Exception("Bad work settings");
 }
 
@@ -39,17 +39,16 @@ $config = [
 ];
 
 $db = new ClickHouseDB\Client($config);
-$db->settings()->apply([
-    'max_execution_time' => 100,
+$db->getSettings()->apply([
     'max_block_size' => 12345
 ]);
 
 
-if ($db->settings()->getSetting('max_execution_time') !== 100) {
+if ($db->getSettings()->getSetting('readonly') !== 2) {
     throw new Exception("Bad work settings");
 }
 
-if ($db->settings()->getSetting('max_block_size') !== 12345) {
+if ($db->getSettings()->getSetting('max_block_size') !== 12345) {
     throw new Exception("Bad work settings");
 }
 

--- a/example/exam11_errors.php
+++ b/example/exam11_errors.php
@@ -25,7 +25,7 @@ $db = new ClickHouseDB\Client([
     'username' => 'x',
     'password' => 'x'
 ]);
-$db->setConnectTimeOut(1);
+$db->setConnectTimeout(1);
 try {
     $db->ping();
 }

--- a/example/exam14_Statistics_in_JSON.php
+++ b/example/exam14_Statistics_in_JSON.php
@@ -8,7 +8,7 @@ $config = include_once __DIR__ . '/00_config_connect.php';
 $db = new ClickHouseDB\Client($config);
 
 //$db->verbose();
-$db->settings()->readonly(false);
+$db->getSettings()->readonly(false);
 
 
 $result = $db->select(

--- a/example/exam15_direct_write_result.php
+++ b/example/exam15_direct_write_result.php
@@ -9,7 +9,7 @@ $config = include_once __DIR__ . '/00_config_connect.php';
 
 
 $db = new ClickHouseDB\Client($config);
-$db->enableHttpCompression(true);
+$db->setHttpCompression(true);
 
 $db->write("DROP TABLE IF EXISTS summing_url_views");
 $db->write('

--- a/example/exam17_sample_data_cityHash64.php
+++ b/example/exam17_sample_data_cityHash64.php
@@ -55,7 +55,7 @@ if ($_flag_create_table) {
     echo "----------------------------------------------------------------------------------------------------\n";
     echo "insert ALL file async + GZIP:\n";
 
-    $db->enableHttpCompression(true);
+    $db->setHttpCompression(true);
     $time_start = microtime(true);
 
     $result_insert = $db->insertBatchFiles('summing_url_views_cityHash64_site_id', $file_data_names, [

--- a/example/exam17_sample_data_inthash.php
+++ b/example/exam17_sample_data_inthash.php
@@ -61,7 +61,7 @@ if ($_flag_create_table) {
     echo "----------------------------------------------------------------------------------------------------\n";
     echo "insert ALL file async + GZIP:\n";
 
-    $db->enableHttpCompression(true);
+    $db->setHttpCompression(true);
     $time_start = microtime(true);
 
     $result_insert = $db->insertBatchFiles('summing_url_views_intHash32_site_id', $file_data_names, [

--- a/example/exam18_log_queries.php
+++ b/example/exam18_log_queries.php
@@ -7,6 +7,6 @@ $config = include_once __DIR__ . '/00_config_connect.php';
 
 $db = new ClickHouseDB\Client($config);
 
-$db->enableLogQueries()->enableHttpCompression();
+$db->enableLogQueries()->setHttpCompression();
 //----------------------------------------
 print_r($db->select('SELECT * FROM system.query_log')->rows());

--- a/example/exam19_readonly_user.php
+++ b/example/exam19_readonly_user.php
@@ -8,7 +8,7 @@ $config = include_once __DIR__ . '/00_config_connect.php';
 $db = new ClickHouseDB\Client($config);
 
 
-$db->enableExtremes(true)->enableHttpCompression();
+$db->enableExtremes(true)->setHttpCompression();
 $db->setReadOnlyUser(true);
 
 
@@ -26,7 +26,7 @@ $db = new ClickHouseDB\Client($config);
 
 //----------------------------------------
 
-$db->enableExtremes(true)->enableHttpCompression();
+$db->enableExtremes(true)->setHttpCompression();
 
 
 

--- a/example/exam20_FormatLine_TSV.php
+++ b/example/exam20_FormatLine_TSV.php
@@ -8,7 +8,7 @@ $config = include_once __DIR__ . '/00_config_connect.php';
 $db = new ClickHouseDB\Client($config);
 
 
-$db->enableExtremes(true)->enableHttpCompression();
+$db->enableExtremes(true)->setHttpCompression();
 
 $db->write("DROP TABLE IF EXISTS xxxx");
 $db->write('

--- a/example/exam21_httpS.php
+++ b/example/exam21_httpS.php
@@ -13,27 +13,16 @@ $db->select('SELECT 11');
 
 
 // ---------------------------------------- ADD HTTPS ----------------------------------------
-$db->https();
+$db->setHttps(true);
 
 $db->select('SELECT 11');
 
 
 
 
-// --------------------- $db->settings()->https(); --------------------------------
+// --------------------- $db->setHtps(); --------------------------------
 
 $db = new ClickHouseDB\Client($config);
 $db->verbose();
-$db->settings()->https();
-$db->select('SELECT 11');
-
-
-
-
-// --------------------- $config['https']=true; --------------------------------
-
-$config['https']=true;
-
-$db = new ClickHouseDB\Client($config);
-$db->verbose();
+$db->setHttps(true);
 $db->select('SELECT 11');

--- a/example/exam22_PROGRESSFUNCTION.php
+++ b/example/exam22_PROGRESSFUNCTION.php
@@ -16,7 +16,7 @@ class progress {
 $db = new ClickHouseDB\Client($config);
 
 // need for test
-$db->settings()->set('max_block_size', 1);
+$db->getSettings()->set('max_block_size', 1);
 
 
 
@@ -29,7 +29,7 @@ $st=$db->select('SELECT number,sleep(0.2) FROM system.numbers limit 5');
 
 
 // ----------------------------------------  ----------------------------------------
-$db->settings()->set('http_headers_progress_interval_ms', 15); // change interval
+$db->getSettings()->set('http_headers_progress_interval_ms', 15); // change interval
 
 $db->progressFunction(['progress','printz']);
 $st=$db->select('SELECT number,sleep(0.1) FROM system.numbers limit 5');

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
         <env name="CLICKHOUSE_PORT" value="8123" />
         <env name="CLICKHOUSE_USER" value="default" />
         <env name="CLICKHOUSE_PASSWORD" value="" />
-        <env name="CLICKHOUSE_DATABASE" value="php_clickhouse" />
+        <env name="CLICKHOUSE_DATABASE" value="default" />
         <env name="CLICKHOUSE_TMPPATH" value="/tmp" />
     </php>
 

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -88,7 +88,7 @@ class Cluster
     public function __construct($connect_params, $settings = [])
     {
         $this->defaultClient = new Client($connect_params, $settings);
-        $this->defaultHostName = $this->defaultClient->getConnectHost();
+        $this->defaultHostName = $this->defaultClient->getHost();
         $this->setNodes(gethostbynamel($this->defaultHostName));
     }
 
@@ -549,11 +549,9 @@ class Cluster
     /**
      * Truncate on all nodes
      * @deprecated
-     * @param string $database_table
-     * @return array
-     * @throws Exception\TransportException
+     * @return mixed[]
      */
-    public function truncateTable($database_table, $timeOut = 2000)
+    public function truncateTable( string $database_table, float $timeout = 2000)  : array
     {
         $out = [];
         list($db, $table) = explode('.', $database_table);
@@ -561,8 +559,8 @@ class Cluster
         // scan need node`s
         foreach ($nodes as $node)
         {
-            $def = $this->client($node)->getTimeout();
-            $this->client($node)->database($db)->setTimeout($timeOut);
+            $def = $this->client($node)->getTransport()->getTimeout();
+            $this->client($node)->setDatabase($db)->setTimeout($timeout);
             $out[$node] = $this->client($node)->truncateTable($table);
             $this->client($node)->setTimeout($def);
         }

--- a/src/Transport/CurlerRequest.php
+++ b/src/Transport/CurlerRequest.php
@@ -2,8 +2,10 @@
 
 namespace ClickHouseDB\Transport;
 
+use const CURLOPT_CONNECTTIMEOUT_MS;
 use const CURLOPT_HTTPGET;
 use const CURLOPT_POST;
+use const CURLOPT_TIMEOUT_MS;
 
 class CurlerRequest
 {
@@ -412,16 +414,12 @@ class CurlerRequest
         return $id . '.' . microtime() . mt_rand(0, 1000000);
     }
 
-    /**
-     * @param bool $flag
-     */
-    public function httpCompression($flag)
+    public function httpCompression(bool $flag) : void
     {
         if ($flag) {
             $this->_httpCompression = $flag;
             $this->options[CURLOPT_ENCODING] = 'gzip';
-        } else
-        {
+        } else {
             $this->_httpCompression = false;
             unset($this->options[CURLOPT_ENCODING]);
         }
@@ -449,40 +447,27 @@ class CurlerRequest
     }
 
     /**
-     * The number of seconds to wait when trying to connect. Use 0 for infinite waiting.
-     *
-     * @param int $seconds
-     * @return $this
-     */
-    public function connectTimeOut($seconds = 1)
-    {
-        $this->options[CURLOPT_CONNECTTIMEOUT] = $seconds;
-        return $this;
-    }
-
-    /**
      * The maximum number of seconds (float) allowed to execute cURL functions.
      *
      * @param float $seconds
      * @return $this
      */
-    public function timeOut($seconds = 10)
+    public function setTimeout(float $seconds = 10) : self
     {
-        return $this->timeOutMs(intval($seconds * 1000));
-    }
+        $this->options[CURLOPT_TIMEOUT_MS] = (int) ($seconds * 1000);
 
-    /**
-     * The maximum allowed number of milliseconds to perform cURL functions.
-     *
-     * @param int $ms millisecond
-     * @return $this
-     */
-    protected function timeOutMs($ms = 10000)
-    {
-        $this->options[CURLOPT_TIMEOUT_MS] = $ms;
         return $this;
     }
 
+    /**
+     * The number of seconds to wait when trying to connect. Use 0 for infinite waiting.
+     */
+    public function setConnectTimeout(float $seconds = 1) : self
+    {
+        $this->options[CURLOPT_CONNECTTIMEOUT_MS] = (int) ($seconds * 1000);
+
+        return $this;
+    }
 
     /**
      * @param array|mixed $data

--- a/tests/BindingsTest.php
+++ b/tests/BindingsTest.php
@@ -195,7 +195,7 @@ final class BindingsTest extends TestCase
     public function testSelectAsKeys()
     {
         // chr(0....255);
-        $this->client->settings()->set('max_block_size', 100);
+        $this->client->getSettings()->set('max_block_size', 100);
 
         $bind['k1']=1;
         $bind['k2']=2;

--- a/tests/FormatQueryTest.php
+++ b/tests/FormatQueryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace ClickHouseDB\Tests;
- 
+
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -49,18 +49,16 @@ final class FormatQueryTest extends TestCase
 
     public function testClientTimeoutSettings()
     {
-        $this->client->database('default');
-
         $timeout = 1.5;
         $this->client->setTimeout($timeout);      // 1500 ms
-        $this->assertSame($timeout, $this->client->getTimeout());
+        $this->assertSame($timeout, $this->client->getTransport()->getTimeout());
 
         $timeout = 10.0;
         $this->client->setTimeout($timeout);      // 10 seconds
-        $this->assertSame($timeout, $this->client->getTimeout());
+        $this->assertSame($timeout, $this->client->getTransport()->getTimeout());
 
         $timeout = 5.0;
-        $this->client->setConnectTimeOut($timeout);      // 5 seconds
-        $this->assertSame($timeout, $this->client->getConnectTimeOut());
+        $this->client->setConnectTimeout($timeout);      // 5 seconds
+        $this->assertSame($timeout, $this->client->getTransport()->getConnectTimeout());
     }
 }

--- a/tests/ProgressAndEscapeTest.php
+++ b/tests/ProgressAndEscapeTest.php
@@ -27,7 +27,7 @@ final class ProgressAndEscapeTest extends TestCase
     {
         global $resultTest;
 
-        $this->client->settings()->set('max_block_size', 1);
+        $this->client->getSettings()->set('max_block_size', 1);
 
         $this->client->progressFunction(function ($data) {
             global $resultTest;

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -2,7 +2,6 @@
 
 namespace ClickHouseDB\Tests;
 
-use ClickHouseDB\Exception\QueryException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,6 +13,9 @@ final class UriTest extends TestCase
 {
     use WithClient;
 
+    /**
+     * @deprecated Replace with DSN support
+     */
     public function testUriMake()
     {
 
@@ -28,49 +30,47 @@ final class UriTest extends TestCase
 
 
         //
-        $this->assertEquals('http://11.12.13.14:8123' , $cli->transport()->getUri());
+        $this->assertEquals('http://11.12.13.14:8123', $cli->getTransport()->getUri());
 
 
-        $cli->https(true);
+        $cli->setHttps(true);
 
-        $this->assertEquals('https://11.12.13.14:8123' , $cli->transport()->getUri());
+        $this->assertEquals('https://11.12.13.14:8123', $cli->getTransport()->getUri());
 
         $config['host']='blabla.com';
         $cli = new \ClickHouseDB\Client($config);
-        $cli->https(true);
+        $cli->setHttps(true);
 
-        $this->assertEquals('https://blabla.com:8123' , $cli->transport()->getUri());
+        $this->assertEquals('https://blabla.com:8123', $cli->getTransport()->getUri());
 
 
         $config['host']='blabla.com:8111';
         $cli = new \ClickHouseDB\Client($config);
-        $this->assertEquals('http://blabla.com:8111' , $cli->transport()->getUri());
+        $this->assertEquals('http://blabla.com:8111', $cli->getTransport()->getUri());
 
         $config['host']='blabla.com/urls';
         $cli = new \ClickHouseDB\Client($config);
-        $this->assertEquals('http://blabla.com/urls' , $cli->transport()->getUri());
+        $this->assertEquals('http://blabla.com/urls', $cli->getTransport()->getUri());
 
 
         $config['host']='blabla.com';
         $config['port']=0;
         $cli = new \ClickHouseDB\Client($config);
-        $this->assertEquals('http://blabla.com' , $cli->transport()->getUri());
+        $this->assertEquals('http://blabla.com', $cli->getTransport()->getUri());
 
         $config['host']='blabla.com';
-        $config['port']=false;
         $cli = new \ClickHouseDB\Client($config);
-        $this->assertEquals('http://blabla.com' , $cli->transport()->getUri());
+        $this->assertEquals('http://blabla.com', $cli->getTransport()->getUri());
 
         $config['host']='blabla.com:8222/path1/path';
-        $config['port']=false;
         $cli = new \ClickHouseDB\Client($config);
-        $this->assertEquals('http://blabla.com:8222/path1/path' , $cli->transport()->getUri());
+        $this->assertEquals('http://blabla.com:8222/path1/path', $cli->getTransport()->getUri());
 
 
         $config['host']='blabla.com:1234/path1/path';
         $config['port']=3344;
         $cli = new \ClickHouseDB\Client($config);
-        $this->assertEquals('http://blabla.com:1234/path1/path' , $cli->transport()->getUri());
+        $this->assertEquals('http://blabla.com:1234/path1/path', $cli->getTransport()->getUri());
 
 
         // exit resetup

--- a/tests/WithClient.php
+++ b/tests/WithClient.php
@@ -7,6 +7,7 @@ namespace ClickHouseDB\Tests;
 use ClickHouseDB\Client;
 use function getenv;
 use function sprintf;
+use const DIRECTORY_SEPARATOR;
 
 trait WithClient
 {
@@ -14,6 +15,9 @@ trait WithClient
     private $client;
 
     private $tmpPath;
+
+    /** @var string */
+    private $currentDbName = 'php_clickhouse_client_test_db';
 
     /**
      * @before
@@ -24,27 +28,32 @@ trait WithClient
         $this->tmpPath = getenv('CLICKHOUSE_TMPPATH') . DIRECTORY_SEPARATOR;
     }
 
-    public function restartClickHouseClient()
+    public function restartClickHouseClient() : void
     {
+        $databaseName = getenv('CLICKHOUSE_DATABASE');
         $config       = [
             'host'     => getenv('CLICKHOUSE_HOST'),
-            'port'     => getenv('CLICKHOUSE_PORT'),
+            'port'     => (int) getenv('CLICKHOUSE_PORT'),
             'username' => getenv('CLICKHOUSE_USER'),
             'password' => getenv('CLICKHOUSE_PASSWORD'),
-
+            'database' => $databaseName,
         ];
 
         $this->client = new Client($config);
-        $databaseName = getenv('CLICKHOUSE_DATABASE');
-        if (!$databaseName || $databaseName==='default') {
-            throw new \Exception('Change CLICKHOUSE_DATABASE, not use default');
-        }
-        if (empty($GLOBALS['phpCH_needFirstCreateDB'])) { // hack use Global VAR, for once create DB
-            $GLOBALS['phpCH_needFirstCreateDB']=true;
-            $this->client->write(sprintf('DROP DATABASE IF EXISTS "%s"', $databaseName));
-            $this->client->write(sprintf('CREATE DATABASE "%s"', $databaseName));
-        }
-        // Change Database
-        $this->client->database($databaseName);
+
+//        if (empty($GLOBALS['phpCH_needFirstCreateDB'])) { // hack use Global VAR, for once create DB
+//            $GLOBALS['phpCH_needFirstCreateDB'] = true;
+        $this->client->write(sprintf('DROP DATABASE IF EXISTS "%s"', $this->currentDbName));
+        $this->client->write(sprintf('CREATE DATABASE "%s"', $this->currentDbName));
+//        }
+        $this->client->setDatabase($this->currentDbName);
+    }
+
+    /**
+     * @after
+     */
+    public function tearDownDataBase() : void
+    {
+
     }
 }


### PR DESCRIPTION
I tried to cleanup Transport with Client a bit. This is first part. I tried to reflect changes in docs and examples as well. Currently it seems to me that there are usualy multiple APIs for the same thing so I'm trying to clean it up and make it more clear, simple so we avoid unwanted side effects.

Eg. `setTimeout` and `setConnectTimeout` influence curl settings (`CURLOPT_TIMEOUT_MS`, `CURLOPT_CONNECTTIMEOUT_MS`). Before this PR it seemed like they controlled [ClickHouse settings](https://clickhouse.yandex/docs/en/operations/settings/settings/#connect_timeout) as they were called via eg. `settings()->max_execution_time`