### PR TITLE
fix clickhouse release 19.5.2.6 error parsing

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -136,7 +136,7 @@ class Statement
         // Code: 192, e.displayText() = DB::Exception: Unknown user x, e.what() = DB::Exception
         // Code: 60, e.displayText() = DB::Exception: Table default.ZZZZZ doesn't exist., e.what() = DB::Exception
 
-        if (preg_match("%Code: (\d+),\se\.displayText\(\) \=\s*DB\:\:Exception\s*:\s*(.*)\,\s*e\.what.*%ius", $body, $mathes)) {
+        if (preg_match("%Code: (\d+),\se\.displayText\(\) \=\s*DB\:\:Exception\s*:\s*(.*)(?:\,\s*e\.what|\(version).*%ius", $body, $mathes)) {
             return ['code' => $mathes[1], 'message' => $mathes[2]];
         }
 


### PR DESCRIPTION
After clean install new release 19.5.2.6 via docker, ClickHouse server errors ends with:
` (version 19.5.2.6 (official build))`
Before:
`, e.what() = DB::Exception`