### PR TITLE
WriteToFile: support for JSONEachRow format

### DIFF
--- a/src/Query/WriteToFile.php
+++ b/src/Query/WriteToFile.php
@@ -13,8 +13,9 @@ class WriteToFile
     const FORMAT_TabSeparatedWithNames = 'TabSeparatedWithNames';
     const FORMAT_CSV                   = 'CSV';
     const FORMAT_CSVWithNames          = 'CSVWithNames';
+    const FORMAT_JSONEACHROW           = 'JSONEachRow';
 
-    private $support_format = ['TabSeparated', 'TabSeparatedWithNames', 'CSV', 'CSVWithNames'];
+    private $support_format = ['TabSeparated', 'TabSeparatedWithNames', 'CSV', 'CSVWithNames', 'JSONEachRow'];
     /**
      * @var string
      */


### PR DESCRIPTION
In case of work with arrays in response values CSV isn't good format.
JSONEachRow works fine and easier to decode.
BTW: I've seen that constant names must be written in upper case (https://github.com/smi2/phpClickHouse/pull/107#discussion_r236236834)