### PR TITLE
Added more debug info for empty response with error

### DIFF
--- a/src/Exception/QueryException.php
+++ b/src/Exception/QueryException.php
@@ -8,6 +8,9 @@ use LogicException;
 
 class QueryException extends LogicException implements ClickHouseException
 {
+    protected $requestDetails = [];
+    protected $responseDetails = [];
+
     public static function cannotInsertEmptyValues() : self
     {
         return new self('Inserting empty values array is not supported in ClickHouse');
@@ -16,5 +19,25 @@ class QueryException extends LogicException implements ClickHouseException
     public static function noResponse() : self
     {
         return new self('No response returned');
+    }
+
+    public function setRequestDetails(array $requestDetails)
+    {
+        $this->requestDetails = $requestDetails;
+    }
+
+    public function getRequestDetails(): array
+    {
+        return $this->requestDetails;
+    }
+
+    public function setResponseDetails(array $responseDetails)
+    {
+        $this->responseDetails = $responseDetails;
+    }
+
+    public function getResponseDetails(): array
+    {
+        return $this->responseDetails;
     }
 }

--- a/src/Transport/CurlerRequest.php
+++ b/src/Transport/CurlerRequest.php
@@ -285,6 +285,16 @@ class CurlerRequest
         }
     }
 
+    public function getDetails(): array
+    {
+        return [
+            'url'        => $this->url,
+            'method'     => $this->method,
+            'parameters' => $this->parameters,
+            'headers'    => $this->headers,
+        ];
+    }
+
     /**
      * @param bool $result
      * @return string

--- a/src/Transport/CurlerResponse.php
+++ b/src/Transport/CurlerResponse.php
@@ -158,6 +158,16 @@ class CurlerResponse
         print_r($this->json());
     }
 
+    public function getDetails(): array
+    {
+        return [
+            'body'    => $this->_body,
+            'headers' => $this->_headers,
+            'error'   => $this->error(),
+            'info'    => $this->_info,
+        ];
+    }
+
     /**
      * @param bool $result
      * @return string


### PR DESCRIPTION
Added more debug info for the response without any error message and with http error code only.

The additional details from `QueryException` can be logged in try/catch block.
