### PR TITLE
fix the exception(multi-statement not allow) when sql end with ';'

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -73,6 +73,11 @@ class Query
         }
         $supportFormats = implode("|",$this->supportFormats);
 
+        $this->sql = trim($this->sql);
+        if (substr($this->sql, -1) == ';') {
+            $this->sql = substr($this->sql, 0, -1);
+        }
+
         $matches = [];
         if (preg_match_all('%(' . $supportFormats . ')%ius', $this->sql, $matches)) {
 


### PR DESCRIPTION
sometimes we write the sql, and end with `;`, but it will throw an exception in `phpClickHouse`, even it is not an error. So we can cut this `;` when we detect it;