### PR TITLE
Add two new types of authentication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
   ],
   "require": {
     "php": "^7.1",
-    "ext-curl": "*"
+    "ext-curl": "*",
+    "ext-json": "*"
   },
   "require-dev": {
     "doctrine/coding-standard": "^5.0",

--- a/example/00_config_connect.php
+++ b/example/00_config_connect.php
@@ -3,5 +3,6 @@ return [
     'host' => '127.0.0.1', // you hot name
     'port' => '8123',
     'username' => 'default',
-    'password' => ''
+    'password' => '',
+    'auth_method' => 1, // On of HTTP::AUTH_METHODS_LIST
 ];

--- a/src/Client.php
+++ b/src/Client.php
@@ -54,6 +54,9 @@ class Client
     /** @var string */
     private $connectPort;
 
+    /** @var int */
+    private $authMethod;
+
     /** @var bool */
     private $connectUserReadonly = false;
 
@@ -79,6 +82,18 @@ class Client
             throw  new \InvalidArgumentException('not set host');
         }
 
+        if (array_key_exists('auth_method', $connectParams)) {
+            if (false === in_array($connectParams['auth_method'], Http::AUTH_METHODS_LIST)) {
+                $errorMessage = sprintf(
+                    'Invalid value for "auth_method" param. Should be one of [%s].',
+                    json_encode(Http::AUTH_METHODS_LIST)
+                );
+                throw  new \InvalidArgumentException($errorMessage);
+            }
+
+            $this->authMethod = $connectParams['auth_method'];
+        }
+
         $this->connectUsername = $connectParams['username'];
         $this->connectPassword = $connectParams['password'];
         $this->connectPort = $connectParams['port'];
@@ -89,7 +104,8 @@ class Client
             $this->connectHost,
             $this->connectPort,
             $this->connectUsername,
-            $this->connectPassword
+            $this->connectPassword,
+            $this->authMethod
         );
 
         $this->transport->addQueryDegeneration(new Bindings());
@@ -239,6 +255,14 @@ class Client
     public function getConnectUsername()
     {
         return $this->connectUsername;
+    }
+
+    /**
+     * @return int
+     */
+    public function getAuthMethod(): int
+    {
+        return $this->authMethod;
     }
 
     /**

--- a/src/Transport/CurlerRequest.php
+++ b/src/Transport/CurlerRequest.php
@@ -445,7 +445,7 @@ class CurlerRequest
      * @param string $password
      * @return $this
      */
-    public function auth($username, $password)
+    public function authByBasicAuth($username, $password)
     {
         $this->options[CURLOPT_USERPWD] = sprintf("%s:%s", $username, $password);
         return $this;


### PR DESCRIPTION
Two new types of authentication have been added
 - HTTP Basic Authentication
 - With URL parameters
The client can specify the authentication method by
specifying the "auth_method" in the `$connectParams`.
Now the client can authenticate using three authentication
methods, as described in the documentation:
https://clickhouse.tech/docs/en/interfaces/http/.

The signature of the `Http` class constructor has been
changed. A new optional argument `$authMethod` has been
added.