### PR TITLE
Drop unsupported PHP versions and upgrade to PHP 7.3+

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,7 +3,7 @@ build:
         analysis:
             environment:
                 php:
-                    version: 7.1
+                    version: 7.3
             cache:
                 disabled: false
                 directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 7.1
-  - 7.2
   - 7.3
+  - 7.4
+  - 8.0
   - nightly
 
 services:
@@ -43,7 +43,13 @@ jobs:
 
     - stage: Test
       env: LOWEST_DEPENDENCIES
-      php: 7.2
+      php: 7.4
+      install:
+        - travis_retry composer update -n --prefer-dist --prefer-lowest
+
+    - stage: Test
+      env: LOWEST_DEPENDENCIES
+      php: 8.0
       install:
         - travis_retry composer update -n --prefer-dist --prefer-lowest
 
@@ -62,7 +68,7 @@ jobs:
 
     - stage: Test
       env: COVERAGE
-      php: 7.1
+      php: 7.3
       before_script:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
         - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi
@@ -75,7 +81,7 @@ jobs:
     - stage: Code Quality
       if: type = pull_request
       env: PULL_REQUEST_CODING_STANDARD
-      php: 7.1
+      php: 7.3
       install: travis_retry composer install --prefer-dist
       script:
         - |

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.3|^8.0",
     "ext-curl": "*",
     "ext-json": "*"
   },
   "require-dev": {
-    "doctrine/coding-standard": "^5.0",
-    "phpstan/phpstan": "^0.10.3",
-    "phpunit/phpunit": "^7",
-    "sebastian/comparator": "~3.0"
+    "doctrine/coding-standard": "^8.2",
+    "phpstan/phpstan": "^0.12",
+    "phpunit/phpunit": "^9.5",
+    "sebastian/comparator": "^4.0"
   },
   "autoload": {
     "psr-4": {

--- a/tests/BindingsTest.php
+++ b/tests/BindingsTest.php
@@ -133,7 +133,7 @@ final class BindingsTest extends TestCase
         ];
 
         $a=$this->client->selectAsync(":a :b :c :aa :bb :cc ", $arr);
-        $this->assertEquals("'[A]' '[B]' '[C]' '[AA]' '[BB]' :cc  FORMAT JSON",$a->sql());
+        $this->assertEquals("'[A]' '[B]' '[C]' '[AA]' '[BB]' :cc FORMAT JSON",$a->sql());
 
         $a=$this->client->selectAsync(":a1 :a2 :a3 :a11 :a23 :a5 :arra", $arr);
         $this->assertEquals("'[A1]' '[A2]' '[A3]' '[A11]' '[A23]' '[a5]' 1,2,3,4 FORMAT JSON",$a->sql());

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -23,7 +23,7 @@ class ClientTest extends TestCase
 {
     use WithClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('Europe/Moscow');
 
@@ -34,7 +34,7 @@ class ClientTest extends TestCase
     /**
      *
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         //
     }
@@ -1010,7 +1010,7 @@ class ClientTest extends TestCase
     public function testVersion()
     {
         $version = $this->client->getServerVersion();
-        $this->assertRegExp('/(^[0-9]+.[0-9]+.[0-9]+.*$)/mi', $version);
+        $this->assertMatchesRegularExpression('/(^[0-9]+.[0-9]+.[0-9]+.*$)/mi', $version);
     }
 
     public function testServerSystemSettings()

--- a/tests/ConditionsTest.php
+++ b/tests/ConditionsTest.php
@@ -128,19 +128,19 @@ final class ConditionsTest extends TestCase
 
         $result=$this->client->selectAsync($select, $input_params)->sql();
 
-        $this->assertNotContains('NOT_SHOW',$result);
-        $this->assertContains('s_empty_check',$result);
-        $this->assertContains('LAST_LINE_1',$result);
-        $this->assertContains('LAST_LINE_2',$result);
-        $this->assertContains('CHECL_IFINT',$result);
-        $this->assertContains('CHECK_INT',$result);
-        $this->assertContains('CHECK_STRING',$result);
-        $this->assertContains('OK_11',$result);
-        $this->assertContains('OK_22',$result);
-        $this->assertContains('OK_33',$result);
-        $this->assertContains('OK_B11',$result);
-        $this->assertContains('OK_B22',$result);
-        $this->assertContains('=today()-3',$result);
+        $this->assertStringNotContainsString('NOT_SHOW',$result);
+        $this->assertStringContainsString('s_empty_check',$result);
+        $this->assertStringContainsString('LAST_LINE_1',$result);
+        $this->assertStringContainsString('LAST_LINE_2',$result);
+        $this->assertStringContainsString('CHECL_IFINT',$result);
+        $this->assertStringContainsString('CHECK_INT',$result);
+        $this->assertStringContainsString('CHECK_STRING',$result);
+        $this->assertStringContainsString('OK_11',$result);
+        $this->assertStringContainsString('OK_22',$result);
+        $this->assertStringContainsString('OK_33',$result);
+        $this->assertStringContainsString('OK_B11',$result);
+        $this->assertStringContainsString('OK_B22',$result);
+        $this->assertStringContainsString('=today()-3',$result);
 
 //        echo "\n----\n$result\n----\n";
 
@@ -221,7 +221,7 @@ final class ConditionsTest extends TestCase
         ];
 
         $this->assertEquals(
-            '|ZERO||  FORMAT JSON',
+            '|ZERO|| FORMAT JSON',
             $this->client->selectAsync('{if FALSE}FALSE{/if}|{if ZERO}ZERO{/if}|{if NULL}NULL{/if}| ' ,$isset)->sql()
         );
 

--- a/tests/FormatQueryTest.php
+++ b/tests/FormatQueryTest.php
@@ -16,7 +16,7 @@ final class FormatQueryTest extends TestCase
     /**
      * @throws Exception
      */
-    public function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('Europe/Moscow');
 

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -21,7 +21,7 @@ final class JsonTest extends TestCase
 
         $state=$this->client->select('SELECT sin(number) as sin,cos(number) as cos FROM {table_name} LIMIT 2 FORMAT JSONEachRow', ['table_name'=>'system.numbers']);
         $checkString='{"sin":0,"cos":1}';
-        $this->assertContains($checkString,$state->rawData());
+        $this->assertStringContainsString($checkString,$state->rawData());
 
 
         $state=$this->client->select('SELECT round(4+sin(number),2) as sin,round(4+cos(number),2) as cos FROM {table_name} LIMIT 2 FORMAT JSONCompact', ['table_name'=>'system.numbers']);

--- a/tests/ProgressAndEscapeTest.php
+++ b/tests/ProgressAndEscapeTest.php
@@ -16,7 +16,7 @@ final class ProgressAndEscapeTest extends TestCase
     /**
      * @throws Exception
      */
-    public function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('Europe/Moscow');
 

--- a/tests/SessionsTest.php
+++ b/tests/SessionsTest.php
@@ -16,7 +16,7 @@ final class SessionsTest extends TestCase
     /**
      * @throws Exception
      */
-    public function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('Europe/Moscow');
 

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -38,7 +38,7 @@ final class StreamTest extends TestCase
 
         $checkString='{"max":0,"cos":1}';
 
-        $this->assertContains($checkString,$bufferCheck);
+        $this->assertStringContainsString($checkString,$bufferCheck);
 
     }
     public function testStreamInsert()

--- a/tests/StrictQuoteLineTest.php
+++ b/tests/StrictQuoteLineTest.php
@@ -19,7 +19,7 @@ class StrictQuoteLineTest extends TestCase
     /**
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->client->write('DROP TABLE IF EXISTS cities');
         $this->client->write('

--- a/tests/Type/UInt64Test.php
+++ b/tests/Type/UInt64Test.php
@@ -22,7 +22,7 @@ final class UInt64Test extends TestCase
     /**
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->client->write('DROP TABLE IF EXISTS uint64_data');
         $this->client->write('


### PR DESCRIPTION
I'm going to use PHP 8 in a project and this library's dependencies are quite out of date.
It's time to move forward. I see no reason for this library support versions below 7.3.
I suggest we can bump the version to 1.4 with only support for PHP ^7.3 and ^8.0.
I took the initiative to make some changes and fix some tests but I couldn't fix them all. So anyway we could start from this point.