### PR TITLE
Fix: prevent enable_http_compression parameter from being overridden

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -127,8 +127,6 @@ class Client
         if (isset($connectParams['sslCA'])) {
             $this->transport->setSslCa($connectParams['sslCA']);
         }
-
-        $this->enableHttpCompression();
     }
 
     /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -33,7 +33,7 @@ class Settings
             'extremes' => false,
             'readonly' => true,
             'max_execution_time' => 20,
-            'enable_http_compression' => 0,
+            'enable_http_compression' => 1,
             'https' => false,
         ];
 


### PR DESCRIPTION
Hello, when I try to set the enable_http_compression parameter through the `$settings` parameter of the constructor, it is replaced by the last line of the constructor which calls `enableHttpCompression` always at true.

I set enable_http_compression to true in default settings and removed that call. This change prevents overwriting.