### PR TITLE
Return type of ClickHouseDB\Statement::current() should either be compatible with Iterator::current()

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -581,6 +581,7 @@ class Statement implements \Iterator
     /**
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current() {
         if (!isset($this->array_data[$this->iterator])) {
             return null;

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -578,6 +578,9 @@ class Statement implements \Iterator
         $this->iterator = 0;
     }
 
+    /**
+     * @return mixed
+     */
     public function current() {
         if (!isset($this->array_data[$this->iterator])) {
             return null;


### PR DESCRIPTION
Fix deprecations

```
2022-06-21T20:09:15+00:00 [info] Deprecated: Return type of ClickHouseDB\Statement::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
2022-06-21T20:09:15+00:00 [info] User Deprecated: Method "Iterator::current()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "ClickHouseDB\Statement" now to avoid errors or add an explicit @return annotation to suppress this message.
```