### PR TITLE
Fix deprecation notice

### DIFF
--- a/src/Transport/CurlerRolling.php
+++ b/src/Transport/CurlerRolling.php
@@ -125,8 +125,8 @@ class CurlerRolling
     {
         $response = curl_multi_getcontent($oneHandle);
         $header_size = curl_getinfo($oneHandle, CURLINFO_HEADER_SIZE);
-        $header = substr($response, 0, $header_size);
-        $body = substr($response, $header_size);
+        $header = substr($response ?? '', 0, $header_size);
+        $body = substr($response ?? '', $header_size);
 
         $n = new CurlerResponse();
         $n->_headers = $this->parse_headers_from_curl_response($header);


### PR DESCRIPTION
`CurlerRolling`: deprecation notice on PHP Version 8.1.7

```
Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in /.../vendor/smi2/phpclickhouse/src/Transport/CurlerRolling.php on line 128

Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in /.../vendor/smi2/phpclickhouse/src/Transport/CurlerRolling.php on line 129
```