### PR TITLE
Support floats in timeout and connect_timeout

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -189,9 +189,9 @@ class Client
     }
 
     /**
-     * @return mixed
+     * @return float
      */
-    public function getTimeout()
+    public function getTimeout(): float
     {
         return $this->settings()->getTimeOut();
     }
@@ -199,15 +199,15 @@ class Client
     /**
      * ConnectTimeOut in seconds ( support 1.5 = 1500ms )
      */
-    public function setConnectTimeOut(int $connectTimeOut)
+    public function setConnectTimeOut(float $connectTimeOut)
     {
         $this->transport()->setConnectTimeOut($connectTimeOut);
     }
 
     /**
-     * @return int
+     * @return float
      */
-    public function getConnectTimeOut()
+    public function getConnectTimeOut(): float
     {
         return $this->transport()->getConnectTimeOut();
     }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -32,7 +32,7 @@ class Settings
         $default = [
             'extremes' => false,
             'readonly' => true,
-            'max_execution_time' => 20,
+            'max_execution_time' => 20.0,
             'enable_http_compression' => 1,
             'https' => false,
         ];
@@ -93,9 +93,9 @@ class Settings
     }
 
     /**
-     * @return mixed
+     * @return float
      */
-    public function getTimeOut()
+    public function getTimeOut(): float
     {
         return $this->get('max_execution_time');
     }
@@ -172,12 +172,12 @@ class Settings
     }
 
     /**
-     * @param int $time
+     * @param float $time
      * @return $this
      */
-    public function max_execution_time($time)
+    public function max_execution_time(float $time)
     {
-        $this->set('max_execution_time', intval($time));
+        $this->set('max_execution_time',$time);
         return $this;
     }
 

--- a/src/Transport/CurlerRequest.php
+++ b/src/Transport/CurlerRequest.php
@@ -488,12 +488,12 @@ class CurlerRequest
     /**
      * The number of seconds to wait when trying to connect. Use 0 for infinite waiting.
      *
-     * @param int $seconds
+     * @param float $seconds
      * @return $this
      */
-    public function connectTimeOut($seconds = 1)
+    public function connectTimeOut(float $seconds = 1.0)
     {
-        $this->options[CURLOPT_CONNECTTIMEOUT] = $seconds;
+        $this->options[CURLOPT_CONNECTTIMEOUT_MS] = (int) ($seconds*1000.0);
         return $this;
     }
 
@@ -503,9 +503,9 @@ class CurlerRequest
      * @param float $seconds
      * @return $this
      */
-    public function timeOut($seconds = 10)
+    public function timeOut(float $seconds = 10)
     {
-        return $this->timeOutMs(intval($seconds * 1000));
+        return $this->timeOutMs((int) ($seconds * 1000.0));
     }
 
     /**
@@ -514,7 +514,7 @@ class CurlerRequest
      * @param int $ms millisecond
      * @return $this
      */
-    protected function timeOutMs($ms = 10000)
+    protected function timeOutMs(int $ms = 10000)
     {
         $this->options[CURLOPT_TIMEOUT_MS] = $ms;
         return $this;

--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -77,9 +77,9 @@ class Http
     /**
      * Count seconds (int)
      *
-     * @var int
+     * @var float
      */
-    private $_connectTimeOut = 5;
+    private $_connectTimeOut = 5.0;
 
     /**
      * @var callable
@@ -413,9 +413,9 @@ class Http
     /**
      * set Connect TimeOut in seconds [CURLOPT_CONNECTTIMEOUT] ( int )
      *
-     * @param int $connectTimeOut
+     * @param float $connectTimeOut
      */
-    public function setConnectTimeOut(int $connectTimeOut)
+    public function setConnectTimeOut(float $connectTimeOut)
     {
         $this->_connectTimeOut = $connectTimeOut;
     }
@@ -425,7 +425,7 @@ class Http
      *
      * @return int
      */
-    public function getConnectTimeOut(): int
+    public function getConnectTimeOut(): float
     {
         return $this->_connectTimeOut;
     }


### PR DESCRIPTION
Currently setConnectTimeOut(0.5) will set CURLOPT_CONNECTTIMEOUT to 0 because of type conversion.

Ive fixed typing and replaced CURLOPT_CONNECTTIMEOUT with CURLOPT_CONNECTTIMEOUT_MS.