### PR TITLE
Change the correct Docker image name

### DIFF
--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
     clickhouse-server:
-        image: yandex/clickhouse-server
+        image: clickhouse/clickhouse-server
         hostname: clickhouse
         container_name: clickhouse
         ports:


### PR DESCRIPTION
As title, since the [Docker image](https://hub.docker.com/r/clickhouse/clickhouse-server/) name has been changed, it should modify the Docker image name in the `docker-compose.yaml` file.