### PR TITLE
Add allow_plugins setting since Composer 2.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,10 @@
       "ClickHouseDB\\Tests\\": "tests/",
       "ClickHouseDB\\Example\\": "example/"
     }
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }


### PR DESCRIPTION
# Changed log

- Since using the `Composer 2.2` version, the Composer plugin need to be set in the `composer.json` file. Otherwise it will cause the following exception message when running the `composer update` command:

```
.......
  dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin w  
  hich is blocked by your allow-plugins config. You may add it to the list if  
   you consider it safe.                                                       
  You can run "composer config --no-plugins allow-plugins.dealerdirect/phpcod  
  esniffer-composer-installer [true|false]" to enable it (true) or disable it  
   explicitly and suppress this exception (false)                              
  See https://getcomposer.org/allow-plugins
.......
```