### PR TITLE
Fix the timeout test assertion

### DIFF
--- a/tests/FormatQueryTest.php
+++ b/tests/FormatQueryTest.php
@@ -61,17 +61,17 @@ final class FormatQueryTest extends TestCase
         $timeout = 0.55;
         $this->client->setTimeout($timeout);      // 1500 ms
         $this->client->select('SELECT 123,123 as ping ')->rows();
-        $this->assertSame(intval($timeout), $this->client->getTimeout());
+        $this->assertSame(intval($timeout), intval($this->client->getTimeout()));
 
         $timeout = 10.0;
         $this->client->setTimeout($timeout);      // 10 seconds
         $this->client->select('SELECT 123,123 as ping ')->rows();
-        $this->assertSame(intval($timeout), $this->client->getTimeout());
+        $this->assertSame(intval($timeout), intval($this->client->getTimeout()));
 
         $timeout = 5.14;
         $this->client->setConnectTimeOut($timeout);      // 5 seconds
         $this->client->select('SELECT 123,123 as ping ')->rows();
-        $this->assertSame(5, $this->client->getConnectTimeOut());
+        $this->assertSame(5.14, $this->client->getConnectTimeOut());
     }
 
 


### PR DESCRIPTION
# Changed log

- Fix these following failed assertions:

```
There was 1 failure:

1) ClickHouseDB\Tests\FormatQueryTest::testClientTimeoutSettings
Failed asserting that 0.0 is identical to 0.

/data/phpClickHouse/tests/FormatQueryTest.php:74
```

```
There was 1 failure:

1) ClickHouseDB\Tests\FormatQueryTest::testClientTimeoutSettings
Failed asserting that 10.0 is identical to 10.

/data/phpClickHouse/tests/FormatQueryTest.php:69
```

```
There was 1 failure:

1) ClickHouseDB\Tests\FormatQueryTest::testClientTimeoutSettings
Failed asserting that 5.14 is identical to 5.

/data/phpClickHouse/tests/FormatQueryTest.php:74
```