### PR TITLE
Distributed queries response metadata

### DIFF
--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -625,6 +625,11 @@ class Http
         }
 
         $query = $this->prepareQuery($sql, $bindings);
+
+        if (strpos($sql, 'CREATE') === 0 || strpos($sql, 'DROP') === 0 || strpos($sql, 'ALTER') === 0) {
+            $query->setFormat('JSON');
+        }
+
         return $this->getRequestWrite($query);
     }
 


### PR DESCRIPTION
Problem:
If we use distributed queries to write, as example
```SQL
DROP TABLE IF EXISTS test_table ON CLUSTER test_cluster
```
the answer will be contains metadata in table format which can't be parsed in `ClickHouseDB\Statement::init()` and as a result throws "_Can`t find meta_" exception.  
This pr fixed it by adding JSON format for queries started from CREATE, DROP or ALTER.  
This does not affect on non-distributed queries as the response to these queries contains nothing for those type of queries.