### PR TITLE
Fixed silent error occurrence on 200 http status code (ExceptionWhileProcessing query error)

### DIFF
--- a/tests/StatementTest.php
+++ b/tests/StatementTest.php
@@ -38,7 +38,7 @@ final class StatementTest extends TestCase
         $this->assertInstanceOf(Statement::class, $statement);
 
         $this->expectException(DatabaseException::class);
-        $this->expectDeprecationMessage($exceptionMessage);
+        $this->expectExceptionMessage($exceptionMessage);
         $this->expectExceptionCode($exceptionCode);
 
         $statement->error();


### PR DESCRIPTION
Fixes issue https://github.com/smi2/phpClickHouse/issues/144

This problem occurs on partially flushed response to the client with 200 status code with further ClickHouse exception.
All details in StatementTest::testIsErrorWithOkStatusCode

I've used _preg_match_ instead of _stripos_ (suggested in https://github.com/smi2/phpClickHouse/issues/144) because regexes precompiles and further calls are much cheaper (about 10 times in my tests of clickhouse error regex). Also _stripos_ speed only 30% faster (and less) than first call of _preg_match_ on string from 10MB to 1000MB.