### PR TITLE
Fixed Issue #206 Php syntax error in php ^7.3

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -183,9 +183,10 @@ class Client
     /**
      * max_execution_time , in int value (seconds)
      *
+     * @param int|float $timeout
      * @return Settings
      */
-    public function setTimeout(int|float $timeout):Settings
+    public function setTimeout($timeout):Settings
     {
         return $this->settings()->max_execution_time(intval($timeout));
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -182,9 +182,6 @@ class Client
 
     /**
      * max_execution_time , in int value (seconds)
-     *
-     * @param int|float $timeout
-     * @return Settings
      */
     public function setTimeout(int $timeout): Settings
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -186,9 +186,9 @@ class Client
      * @param int|float $timeout
      * @return Settings
      */
-    public function setTimeout($timeout):Settings
+    public function setTimeout(int $timeout): Settings
     {
-        return $this->settings()->max_execution_time(intval($timeout));
+        return $this->settings()->max_execution_time($timeout);
     }
 
     /**


### PR DESCRIPTION
This problem occurs because that syntax is supported only for PHP 8.0 and higher. Using it breaks support for PHP7.

In this pull request, I moved the parameter requirements from attribute definition to phpdoc to fix this problem.