### PR TITLE
Fix getTimeout method return type

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -189,7 +189,7 @@ class Client
     }
 
     /**
-     * @return float
+     * @return int
      */
     public function getTimeout(): int
     {


### PR DESCRIPTION
Fixing return type in DocBlock.

Checked code deeper:
```php
public function getTimeOut(): int
{
    return intval($this->get('max_execution_time'));
}
```