### PR TITLE
Fix write method format

### DIFF
--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -618,7 +618,7 @@ class Http
      * @return CurlerRequest
      * @throws \ClickHouseDB\Exception\TransportException
      */
-    private function prepareWrite($sql, $bindings = []): CurlerRequest
+    private function prepareWrite($sql, $bindings = [], ?string $forceResponseFormat = null): CurlerRequest
     {
         if ($sql instanceof Query) {
             return $this->getRequestWrite($sql);
@@ -626,8 +626,8 @@ class Http
 
         $query = $this->prepareQuery($sql, $bindings);
 
-        if (strpos($sql, 'CREATE') === 0 || strpos($sql, 'DROP') === 0 || strpos($sql, 'ALTER') === 0) {
-            $query->setFormat('JSON');
+        if (null !== $forceResponseFormat) {
+            $query->setFormat($forceResponseFormat);
         }
 
         return $this->getRequestWrite($query);
@@ -689,9 +689,9 @@ class Http
      * @return Statement
      * @throws \ClickHouseDB\Exception\TransportException
      */
-    public function write($sql, array $bindings = [], $exception = true): Statement
+    public function write($sql, array $bindings = [], $exception = true, ?string $forceResponseFormat = null): Statement
     {
-        $request = $this->prepareWrite($sql, $bindings);
+        $request = $this->prepareWrite($sql, $bindings, $forceResponseFormat);
         $this->_curler->execOne($request);
         $response = new Statement($request);
         if ($exception) {


### PR DESCRIPTION
This PR https://github.com/smi2/phpClickHouse/pull/190 brings breaking changes. 

First of all, we can not execute CREATE, DROP, ALTER without `ON CLUSTER`. Cause `CREATE TABLE blabla ... FORMAT JSON` will produce syntax error exception
Second, this was very bad solution. `0 === strpos`? What if query will have comment in start?

My PR fixes this issue, but breaks old code. But i this this is much better solution than the current one