### PR TITLE
Do not add unexpected FORMAT JSON for not distributed queries

### DIFF
--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -626,6 +626,10 @@ class Http
 
         $query = $this->prepareQuery($sql, $bindings);
 
+        if (strpos($sql, 'ON CLUSTER') === false) {
+            return $this->getRequestWrite($query);
+        }
+
         if (strpos($sql, 'CREATE') === 0 || strpos($sql, 'DROP') === 0 || strpos($sql, 'ALTER') === 0) {
             $query->setFormat('JSON');
         }


### PR DESCRIPTION
That changes https://github.com/smi2/phpClickHouse/pull/190 prevent that queries from being executed:
`CREATE FUNCTION ...` or  `DROP FUNCTION ...`

The proposed solution in [pull request #214](https://github.com/smi2/phpClickHouse/pull/214) resolves this specific issue. However, it's essential to acknowledge that this fix might introduce potential compatibility issues with existing codebases.

It seems that the changes made in https://github.com/smi2/phpClickHouse/pull/190 addressed a specific case, but other common scenarios may have been overlooked, so I've implemented an early exit from function when `ON CLUSTER` does not exist.