### PR TITLE
Support Int64 type for SELECT queries

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -286,7 +286,9 @@ class Statement implements \Iterator
                 $r[] = $rows;
             } else {
                 foreach ($this->meta as $meta) {
-                    $r[$meta['name']] = $rows[$meta['name']];
+                    $r[$meta['name']] = ($meta['type'] === 'Int64')
+                        ? (int) $rows[$meta['name']]
+                        : $rows[$meta['name']];
                 }
             }
 

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -286,7 +286,7 @@ class Statement implements \Iterator
                 $r[] = $rows;
             } else {
                 foreach ($this->meta as $meta) {
-                    $r[$meta['name']] = ($meta['type'] === 'Int64')
+                    $r[$meta['name']] = $meta['type'] === 'Int64'
                         ? (int) $rows[$meta['name']]
                         : $rows[$meta['name']];
                 }


### PR DESCRIPTION
Make int type from Int64 response, because Int64 columns returns as a string now