### PR TITLE
Support Enums in ValueFormatter.php

### DIFF
--- a/src/Quote/ValueFormatter.php
+++ b/src/Quote/ValueFormatter.php
@@ -42,6 +42,10 @@ class ValueFormatter
             return $value->getValue();
         }
 
+        if (is_object($value) && property_exists($value, 'value')) {
+            return $value->value;
+        }
+
         if (is_object($value) && is_callable([$value, '__toString'])) {
             $value = (string) $value;
         }


### PR DESCRIPTION
This snippet adds support for string backed PHP Enums.

Example:
```php
enum Animal: string {
   case DOG = 'dog';
   case CAT = 'cat';
   case BIRD = 'bird';
}
```