### PR TITLE
Fix metadata parsing for distributed RENAME queries

### DIFF
--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -636,8 +636,12 @@ class Http
         if (strpos($sql, 'ON CLUSTER') === false) {
             return $this->getRequestWrite($query);
         }
-
-        if (strpos($sql, 'CREATE') === 0 || strpos($sql, 'DROP') === 0 || strpos($sql, 'ALTER') === 0) {
+        if (
+            str_starts_with($sql, 'CREATE')
+            || str_starts_with($sql, 'DROP')
+            || str_starts_with($sql, 'ALTER')
+            || str_starts_with($sql, 'RENAME')
+        ) {
             $query->setFormat('JSON');
         }
 


### PR DESCRIPTION
**Problem**:
Similar to issue described in #190, when executing RENAME queries (RENAME TABLE, etc.) on distributed ClickHouse clusters, the response contains metadata in table format which cannot be parsed by ClickHouseDB\Statement::init(), resulting in `Can't find meta` exception.

**Solution**:
This PR extends the fix from #190 to include RENAME queries by adding JSON format for queries starting with "RENAME". This ensures proper metadata parsing for distributed RENAME operations while maintaining backward compatibility with non-distributed queries.

**Release Request**:
Could you please consider creating a new release after merging this PR? This fix addresses a critical issue that prevents RENAME operations from working in distributed environments, and having it available in a tagged release would be greatly appreciated for deployments.
