### PR TITLE
Fix simple bindings added to url causing "No URL set" / "out of memory" errors with big insert queries

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -3,6 +3,8 @@
 namespace ClickHouseDB\Query;
 
 use ClickHouseDB\Exception\QueryException;
+use ClickHouseDB\Query\Degeneration\Bindings;
+use ClickHouseDB\Query\Degeneration\Conditions;
 use function sizeof;
 
 class Query
@@ -112,10 +114,16 @@ class Query
         return $this->format;
     }
 
+    /**
+     * Check if the sql contains bindings like {p1:UInt8}.
+     *
+     * Check the original SQL before degeneration to prevent data that matches the same regex by accident causing adding bindings to the url
+     * For backwards compatibility use the degenerated sql when custom degenerations are found
+     */
     public function isUseInUrlBindingsParams():bool
     {
         //  'query=select {p1:UInt8} + {p2:UInt8}' -F "param_p1=3" -F "param_p2=4"
-        return preg_match('#{[\w+]+:[\w+()]+}#',$this->originalSql);
+        return preg_match('#{[\w+]+:[\w+()]+}#', $this->hasCustomDegenerations() ? $this->sql : $this->originalSql);
 
     }
     public function getUrlBindingsParams():array
@@ -164,5 +172,12 @@ class Query
     public function __toString()
     {
         return $this->toSql();
+    }
+
+    private function hasCustomDegenerations(): bool
+    {
+        return count(array_filter($this->degenerations, function (Degeneration $degeneration) {
+            return !in_array($degeneration::class, [Conditions::class, Bindings::class]);
+        })) > 0;
     }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace ClickHouseDB\Tests;
+
+use ClickHouseDB\Query\Degeneration;
+use ClickHouseDB\Query\Query;
+use PHPUnit\Framework\TestCase;
+
+class QueryTest extends TestCase
+{
+    /**
+     * Test that isUseInUrlBindingsParams returns true when SQL contains a binding with the format {param:type}
+     */
+    public function testIsUseInUrlBindingsParamsWithValidBinding(): void
+    {
+        $sql = 'SELECT {p1:UInt8} + {p2:UInt8}';
+        $query = new Query($sql);
+
+        $this->assertEquals('SELECT {p1:UInt8} + {p2:UInt8}', $query->toSql());
+        $this->assertTrue($query->isUseInUrlBindingsParams());
+    }
+    
+    /**
+     * Test that isUseInUrlBindingsParams returns false when SQL doesn't contain a binding with the format {param:type}
+     */
+    public function testIsUseInUrlBindingsParamsWithNoBinding(): void
+    {
+        $sql = 'SELECT 1 + :two';
+        $degeneration = new Degeneration\Bindings();
+        $degeneration->bindParams([
+            'two' => 2,
+        ]);
+        $query = new Query($sql, [$degeneration]);
+
+        $this->assertEquals('SELECT 1 + 2', $query->toSql());
+        $this->assertFalse($query->isUseInUrlBindingsParams());
+    }
+    
+    /**
+     * Test that isUseInUrlBindingsParams returns false when SQL contains a similar pattern in a binding value
+     */
+    public function testIsUseInUrlBindingsParamsWithSimilarPatternInValue(): void
+    {
+        $sql = 'INSERT INTO a (b) VALUES (:simple_bind)';
+        $degeneration = new Degeneration\Bindings();
+        $degeneration->bindParams([
+            'simple_bind' => '{foo:bar}',
+        ]);
+        $query = new Query($sql, [$degeneration]);
+
+        $this->assertEquals("INSERT INTO a (b) VALUES ('{foo:bar}')", $query->toSql());
+        $this->assertFalse($query->isUseInUrlBindingsParams());
+    }
+}


### PR DESCRIPTION
### What
Detect typed parameter placeholders (`{name:Type}`) against the *original* SQL (before degenerations),
so JSON data injected during degenerations does not erroneously trigger URL `param_*`.

### Why
When JSON contains strings like "{foo:bar}", the current regex runs on the mutated SQL and
thinks we use typed placeholders, causing all simple bindings (:non-typed-binding) to be appended to the URL. With large INSERT batches
this creates extremely long URLs (e.g. >10 MB) and leads to cURL errors like "No URL set!" or "Out of memory".

### How
- Add `originalSQL` to `Query` and run `isUseInUrlBindingsParams()` against it.
- Keep existing behavior for real typed placeholders.

### Backward compatibility
- No breaking changes: fall back on previous behaviour when custom Degenerations are detected to avoid failure when a custom degeneration class adds typed parameter placeholders to the sql

### Tests
- Added tests for Query (ClickHouseDB\Tests\Query::testIsUseInUrlBindingsParamsWithSimilarPatternInValue reproduces the issue)