### PR TITLE
fix: Remove 'FORMAT JSON' from CREATE, DROP, ALTER and RENAME statements

### DIFF
--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -637,10 +637,10 @@ class Http
             return $this->getRequestWrite($query);
         }
         if (
-            str_starts_with($sql, 'CREATE')
-            || str_starts_with($sql, 'DROP')
-            || str_starts_with($sql, 'ALTER')
-            || str_starts_with($sql, 'RENAME')
+            !str_starts_with($sql, 'CREATE')
+            && !str_starts_with($sql, 'DROP')
+            && !str_starts_with($sql, 'ALTER')
+            && !str_starts_with($sql, 'RENAME')
         ) {
             $query->setFormat('JSON');
         }


### PR DESCRIPTION
Removes 'FORMAT JSON' from CREATE, DROP, ALTER and RENAME statements when executing queries 'ON CLUSTER'.

Specifying output format is only supported for SELECT and INSERT statements.
See: https://clickhouse.com/docs/interfaces/formats

Fixes: https://github.com/smi2/phpClickHouse/issues/241

This PR differs from #214, which is stale / conflicts with the latest version.
This PR only inverts the logic that does not work as intended, it does not add an extra parameter to the write() method like #214.

This change/fix works for my particular use-case. But do not know if I am missing something. Please discuss if this is the correct fix. We might want to make the 'FORMAT JSON' forced format statement optional as in #214. Or maybe we should allow-list SELECT/INSERT statements instead of deny-listing.