### PR TITLE
Fix: Handle null content_type in hasErrorClickhouse()

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -152,8 +152,8 @@ class Statement implements \Iterator
         return false;
     }
 
-    private function hasErrorClickhouse(string $body, string $contentType): bool {
-        if (false === stripos($contentType, 'application/json')) {
+    private function hasErrorClickhouse(string $body, ?string $contentType): bool {
+        if ($contentType === null || false === stripos($contentType, 'application/json')) {
             return preg_match(self::CLICKHOUSE_ERROR_REGEX, $body) === 1;
         }
 


### PR DESCRIPTION
## Issue 
We were flooded with lot of TypeError when we upgraded to `smi2/phpClickHouse` version 1.6.0 
This is the error we found in our log:
```
TypeError
ClickHouseDB\Statement::hasErrorClickhouse(): Argument #2 ($contentType) must be of type string, null given, called in /home/www/client_api/vendor/smi2/phpclickhouse/src/Statement.php on line 226
```
This null case should be handled properly as `$this->response()->content_type()` Curl can return null on content type

## Summary
  - Fixes a potential fatal error when `content_type` is null in the `hasErrorClickhouse()` method
  - Changes the `$contentType` parameter type from `string` to `?string` to accept null values
  - Adds explicit null check before calling `stripos()` to prevent type errors

  ## Changes
  - Modified `Statement.php:155` to accept nullable content type parameter
  - Added null safety check in conditional logic