### PR TITLE
remove deprecated curl_close() call (PHP 8.5 deprecation)

### DIFF
--- a/src/Transport/CurlerRequest.php
+++ b/src/Transport/CurlerRequest.php
@@ -140,9 +140,6 @@ class CurlerRequest
 
     public function close()
     {
-        if ($this->handle) {
-            curl_close($this->handle);
-        }
         $this->handle = null;
     }
 


### PR DESCRIPTION
## Problem
The `curl_close()` function call in `src/Transport/CurlerRequest.php` triggers a deprecation warning in PHP 8.5+ environments:
```
PHP Deprecated: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0
```

## Root Cause
According to PHP documentation:
- `curl_close()` has had **no effect** since PHP 8.0
- The function is officially **deprecated** as of PHP 8.5
- cURL handles are automatically cleaned up when they go out of scope

## Solution
Removed the unnecessary `curl_close($this->handle)` call from the `CurlerRequest::close()` method.
