### PR TITLE
Correctly encode array for native param binding

### DIFF
--- a/doc/native-params.md
+++ b/doc/native-params.md
@@ -58,10 +58,22 @@ $db->selectWithParams(
     ['id' => UUID::fromString('6d38d288-5b13-4714-b6e4-faa59ffd49d8')]
 );
 
-// Array
+// Array of integers
 $db->selectWithParams(
     'SELECT {arr:Array(UInt32)} as arr',
     ['arr' => [1, 2, 3]]
+);
+
+// Array of strings — encoded as ['val1','val2'] (single-quoted, not JSON double-quoted)
+$db->selectWithParams(
+    'SELECT {arr:Array(String)} as arr',
+    ['arr' => ['foo', 'bar', 'baz']]
+);
+
+// Nested arrays
+$db->selectWithParams(
+    'SELECT {arr:Array(Array(UInt32))} as arr',
+    ['arr' => [[1, 2], [3, 4]]]
 );
 
 // IPv4 / IPv6

--- a/docs/native-params.md
+++ b/docs/native-params.md
@@ -65,10 +65,22 @@ $db->selectWithParams(
     ['id' => UUID::fromString('6d38d288-5b13-4714-b6e4-faa59ffd49d8')]
 );
 
-// Array
+// Array of integers
 $db->selectWithParams(
     'SELECT {arr:Array(UInt32)} as arr',
     ['arr' => [1, 2, 3]]
+);
+
+// Array of strings — encoded as ['val1','val2'] (single-quoted, not JSON double-quoted)
+$db->selectWithParams(
+    'SELECT {arr:Array(String)} as arr',
+    ['arr' => ['foo', 'bar', 'baz']]
+);
+
+// Nested arrays
+$db->selectWithParams(
+    'SELECT {arr:Array(Array(UInt32))} as arr',
+    ['arr' => [[1, 2], [3, 4]]]
 );
 
 // IPv4 / IPv6

--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -837,7 +837,15 @@ class Http
             return $value ? '1' : '0';
         }
         if (is_array($value)) {
-            return json_encode($value);
+            $arrayValues = [];
+            foreach ($value as $val) {
+                if (is_string($val)) {
+                    $arrayValues[] = sprintf("'%s'", $val);
+                    continue;
+                }
+                $arrayValues[] = $this->convertParamValue($val);
+            }
+            return sprintf('[%s]', implode(',', $arrayValues));
         }
         if ($value === null) {
             return '\\N';

--- a/tests/NativeParamsTest.php
+++ b/tests/NativeParamsTest.php
@@ -94,6 +94,36 @@ final class NativeParamsTest extends TestCase
         $this->assertNull($result->fetchOne('val'));
     }
 
+    public function testSelectWithUInt32ArrayParam(): void
+    {
+        $result = $this->client->selectWithParams(
+            'SELECT {arr:Array(UInt32)} as arr',
+            ['arr' => [1, 2, 3]]
+        );
+
+        $this->assertEquals([1, 2, 3], $result->fetchOne('arr'));
+    }
+
+    public function testSelectWithStringArrayParam(): void
+    {
+        $result = $this->client->selectWithParams(
+            'SELECT {arr:Array(String)} as arr',
+            ['arr' => ['foo', 'bar', 'baz']]
+        );
+
+        $this->assertEquals(['foo', 'bar', 'baz'], $result->fetchOne('arr'));
+    }
+
+    public function testSelectWithEmptyArrayParam(): void
+    {
+        $result = $this->client->selectWithParams(
+            'SELECT {arr:Array(UInt32)} as arr',
+            ['arr' => []]
+        );
+
+        $this->assertEquals([], $result->fetchOne('arr'));
+    }
+
     public function testSelectWithPerQuerySettings(): void
     {
         $result = $this->client->selectWithParams(


### PR DESCRIPTION
  Fix incorrect array encoding for native parameter binding

  Problem

  When passing an Array type to selectWithParams() or writeWithParams(), the previous implementation serialized the array using json_encode():

```
  if (is_array($value)) {
      return json_encode($value);
  }
```
  This produced JSON encoding — double-quoted strings and JSON syntax:

`["foo","bar","baz"]`

  ClickHouse's native HTTP parameter protocol expects array literals with single-quoted strings:

`['foo','bar','baz']`

  The double-quoted output caused a query error when executing any native param query with a Array(String) parameter.

  Fix

  Replaced json_encode with a recursive approach that delegates each element back through convertParamValue(), with a special case for string elements which are wrapped in single
  quotes:

```
  if (is_array($value)) {
      $arrayValues = [];
      foreach ($value as $val) {
          if (is_string($val)) {
              $arrayValues[] = sprintf("'%s'", $val);
              continue;
          }
          $arrayValues[] = $this->convertParamValue($val);
      }
      return sprintf('[%s]', implode(',', $arrayValues));
  }

```
  This correctly handles:
  - Array(String) → ['foo','bar']
  - Array(UInt32) → [1,2,3]
  - Array(Array(...)) — nested arrays via recursion