### PR TITLE
Fix false positive error detection when JSON data contains ClickHouse exception text

### DIFF
--- a/src/Statement.php
+++ b/src/Statement.php
@@ -111,7 +111,15 @@ class Statement implements \Iterator
 
         if (strlen($body) > 4096) {
             $tail = substr($body, -4096);
-            return preg_match(self::CLICKHOUSE_ERROR_REGEX, $tail) === 1;
+            if (preg_match(self::CLICKHOUSE_ERROR_REGEX, $tail) === 1) {
+                // Regex also matches if the actual data contains a ClickHouse error
+                // string. Use json_validate() to confirm the response is truly broken.
+                if (function_exists('json_validate')) {
+                    return !json_validate($body);
+                }
+                return true;
+            }
+            return false;
         }
 
         try {

--- a/tests/LargeStreamTest.php
+++ b/tests/LargeStreamTest.php
@@ -66,6 +66,42 @@ final class LargeStreamTest extends TestCase
     }
 
     /**
+     * Large body with valid JSON containing ClickHouse error text as data.
+     */
+    public function testLargeJsonWithErrorPatternInDataIsNotError(): void
+    {
+        if (!function_exists('json_validate')) {
+            $this->markTestSkipped('json_validate() not available');
+        }
+
+        $rows = [];
+        for ($i = 0; $i < 100; $i++) {
+            $rows[] = '{"id":' . $i . ',"message":"Code: 60. DB::Exception: Table default.xxx doesn\'t exist. (UNKNOWN_TABLE) (version 24.3.2.23 (official build))"}';
+        }
+        $body = '{"meta":[{"name":"id","type":"UInt64"},{"name":"message","type":"String"}],'
+            . '"data":[' . implode(',', $rows) . '],'
+            . '"rows":100,'
+            . '"statistics":{"elapsed":0.001,"rows_read":100,"bytes_read":4096}}';
+
+        // Ensure body exceeds the 4096-byte threshold
+        $this->assertGreaterThan(4096, strlen($body));
+
+        $responseMock = $this->createMock(CurlerResponse::class);
+        $responseMock->method('http_code')->willReturn(200);
+        $responseMock->method('error_no')->willReturn(0);
+        $responseMock->method('content_type')->willReturn('application/json; charset=UTF-8');
+        $responseMock->method('body')->willReturn($body);
+
+        $requestMock = $this->createMock(CurlerRequest::class);
+        $requestMock->method('response')->willReturn($responseMock);
+        $requestMock->method('isResponseExists')->willReturn(true);
+
+        $statement = new Statement($requestMock);
+
+        $this->assertFalse($statement->isError());
+    }
+
+    /**
      * Small body with valid JSON should still be checked for JSON validity.
      */
     public function testSmallInvalidJsonDetected(): void


### PR DESCRIPTION
## Summary

- When querying tables that store ClickHouse exceptions as data (e.g. error tracking systems), `hasErrorClickhouse()` can falsely flag valid responses as errors if the exception text appears in the last 4096 bytes of the response body.
- On PHP 8.3+, uses `json_validate()` as a confirmation step when the tail-regex matches: if the response is structurally valid JSON, the query succeeded and the match is just data.
- Zero change in behaviour on PHP < 8.3. Zero overhead on the common path (regex doesn't match).

## Problem

The `> 4096 byte` branch in `hasErrorClickhouse()` checks the last 4096 bytes of a JSON response against `CLICKHOUSE_ERROR_REGEX`. This exists to detect mid-stream errors (where ClickHouse appends error text to an already-streaming HTTP 200 response, breaking the JSON structure).

However, if the response **data** legitimately contains ClickHouse exception strings (e.g. an error tracking system storing exceptions in a ClickHouse table), and that text lands in the tail of the response, it triggers a false positive.

## Solution

When the regex matches in the tail, call `json_validate($body)` (PHP 8.3+) before concluding there's an error:
- Valid JSON → query succeeded, the match is just data → return `false`
- Invalid JSON → the response structure is broken by a real mid-stream error → return `true`

`json_validate()` is O(1) memory (no decoded structure allocated) and only runs in the  case where the regex already matched.