### PR TITLE
fix: undo double-quote escaping from addslashes for ClickHouse compatibility

### DIFF
--- a/src/Quote/ValueFormatter.php
+++ b/src/Quote/ValueFormatter.php
@@ -58,7 +58,7 @@ class ValueFormatter
 
     private static function escapeString(string $value): string
     {
-        return addslashes($value);
+        return str_replace('\"', '"', addslashes($value));
     }
 
     private static function formatStringParameter(string $value): string


### PR DESCRIPTION
## Problem

`ValueFormatter::escapeString()` uses PHP's `addslashes()` to escape string values for ClickHouse SQL.

`addslashes()` escapes 4 characters: `'`, `"`, `\`, and NUL.

However, ClickHouse single-quoted string literals do **not** recognize `\"` as a valid escape sequence. When string data contains double quotes (e.g., JSON like `{"key":"value"}`), the escaped output `\"` causes:

`Code: 62. DB::Exception: SYNTAX_ERROR`

## Root Cause

The library has two escaping paths that are inconsistent:

1. **`StrictQuoteLine::encodeString()`** (used by `Client::insert()`) — correctly escapes only `'` and `\` via regex, leaving `"` untouched. ✅
2. **`ValueFormatter::escapeString()`** (used by `Bindings::process()` via `Client::write()`) — uses `addslashes()` which also escapes `"`. ❌

`addslashes()` is a PHP/MySQL function. ClickHouse is not MySQL — `\"` is not a valid escape inside single-quoted strings.

## Fix

Keep `addslashes()` but undo the unnecessary double-quote escaping:

```php
private static function escapeString(string $value): string
{
    return str_replace('\"', '"', addslashes($value));
}
This is a minimal one-line change that:

Keeps addslashes() for \, ', and NUL escaping (all valid in ClickHouse)

Only undoes the \" → " which is invalid in ClickHouse

Aligns ValueFormatter with StrictQuoteLine::encodeString() which already correctly leaves " unescaped

Reproduction
PHP
$client->write(
    "INSERT INTO test_table VALUES (:json_col)",
    ['json_col' => '{"key":"value"}']
);
// Before: SYNTAX_ERROR (Code 62) due to \"
// After:  Success